### PR TITLE
first draft of match command

### DIFF
--- a/pds.conf
+++ b/pds.conf
@@ -20,6 +20,7 @@ extra_compiler_opts = "-safe-string"
 install = false
 deps = [
      "containers",
+     "csv",
      "logs",
      "uri",
      "ppx_deriving",

--- a/src/oiq/oiq.ml
+++ b/src/oiq/oiq.ml
@@ -11,4 +11,16 @@ let match_ ~pricing_root ~resource_files ~output =
   CCList.iter
     (fun ms -> CCList.iter (fun mk -> Printf.printf "%s\n" mk) @@ Oiq_match_set.to_list ms)
     match_sets;
-  raise (Failure "NYI")
+  (*
+  1. Open pricing_root and iterate across rows
+  2. Read each row's match set and look for match in TF match sets
+  3. Print all matching rows
+  *)
+  (* let ic = open_in pricing_root in *)
+  (* let csv_stream = Csv.of_channel ic in *)
+  (* let _headers = Csv.next csv_stream in *)
+  (* let fn r = *)
+  (*   Oiq_prices.Product.of_row r |> Oiq_prices.Product.to_match_str |> Printf.printf "match str %s" *)
+  (* in *)
+  (* Csv.iter ~f:fn csv_stream; *)
+  raise (Failure "WE ARE PRINTING LINES")

--- a/src/oiq/oiq.ml
+++ b/src/oiq/oiq.ml
@@ -7,20 +7,29 @@ let match_ ~pricing_root ~resource_files ~output =
     | `Unknown -> raise (Failure "NYI")
   in
   let resources = CCList.flat_map extract_one resource_files in
-  let match_sets = CCList.map Oiq_tf.Resource.to_match_set resources in
+  let res_ms_pairs = CCList.map (fun r -> (r, Oiq_tf.Resource.to_match_set r)) resources in
+
+  (*
   CCList.iter
     (fun ms -> CCList.iter (fun mk -> Printf.printf "%s\n" mk) @@ Oiq_match_set.to_list ms)
-    match_sets;
+    ms_resources;
+    *)
+
   (*
   1. Open pricing_root and iterate across rows
   2. Read each row's match set and look for match in TF match sets
   3. Print all matching rows
   *)
-  (* let ic = open_in pricing_root in *)
-  (* let csv_stream = Csv.of_channel ic in *)
-  (* let _headers = Csv.next csv_stream in *)
-  (* let fn r = *)
-  (*   Oiq_prices.Product.of_row r |> Oiq_prices.Product.to_match_str |> Printf.printf "match str %s" *)
-  (* in *)
-  (* Csv.iter ~f:fn csv_stream; *)
-  raise (Failure "WE ARE PRINTING LINES")
+  let csv_stream = Csv.of_channel @@ open_in @@ pricing_root ^ "/prices.csv" in
+  let _headers = Csv.next csv_stream in
+
+  let will_it_blend acc row =
+    let p = Oiq_prices.Product.of_row row in
+    let prod_ms = Oiq_prices.Product.to_match_set p in
+    let price_matcher res_ms = Oiq_match_set.subset ~super:res_ms prod_ms in
+    let matched_res = CCList.filter CCFun.(snd %> price_matcher) res_ms_pairs in
+    let match_pairs = CCList.map (fun (r, _) -> Oiq_match_pair.make r p) matched_res in
+    CCList.fold_left (fun acc mp -> Oiq_match_file.add acc mp) acc match_pairs
+  in
+  let match_file = Csv.fold_left ~f:will_it_blend ~init:(Oiq_match_file.make []) csv_stream in
+  Printf.printf "%s\n" @@ Yojson.Safe.to_string @@ Oiq_match_file.to_yojson match_file

--- a/src/oiq/oiq_match_file.ml
+++ b/src/oiq/oiq_match_file.ml
@@ -1,0 +1,5 @@
+type t = { oiq : Oiq_match_pair.t list } [@@deriving to_yojson]
+
+let make pairs = { oiq = pairs }
+let add mf mp = { oiq = mp :: mf.oiq }
+let to_yojson t = to_yojson t

--- a/src/oiq/oiq_match_file.ml
+++ b/src/oiq/oiq_match_file.ml
@@ -1,5 +1,5 @@
-type t = { oiq : Oiq_match_pair.t list } [@@deriving to_yojson]
+type t = { matches : Oiq_match_pair.t list } [@@deriving to_yojson]
 
-let make pairs = { oiq = pairs }
-let add mf mp = { oiq = mp :: mf.oiq }
+let make pairs = { matches = pairs }
+let add mf mp = { matches = mp :: mf.matches }
 let to_yojson t = to_yojson t

--- a/src/oiq/oiq_match_file.mli
+++ b/src/oiq/oiq_match_file.mli
@@ -1,5 +1,4 @@
-type t
+type t [@@deriving to_yojson]
 
 val make : Oiq_match_pair.t list -> t
 val add : t -> Oiq_match_pair.t -> t
-val to_yojson : t -> Yojson.Safe.t

--- a/src/oiq/oiq_match_file.mli
+++ b/src/oiq/oiq_match_file.mli
@@ -1,0 +1,5 @@
+type t
+
+val make : Oiq_match_pair.t list -> t
+val add : t -> Oiq_match_pair.t -> t
+val to_yojson : t -> Yojson.Safe.t

--- a/src/oiq/oiq_match_pair.ml
+++ b/src/oiq/oiq_match_pair.ml
@@ -1,0 +1,8 @@
+type t = {
+  resource : Oiq_tf.Resource.t;
+  product : Oiq_prices.Product.t;
+}
+[@@deriving to_yojson]
+
+let make resource product = { resource; product }
+let to_yojson t = to_yojson t

--- a/src/oiq/oiq_match_pair.ml
+++ b/src/oiq/oiq_match_pair.ml
@@ -5,4 +5,3 @@ type t = {
 [@@deriving to_yojson]
 
 let make resource product = { resource; product }
-let to_yojson t = to_yojson t

--- a/src/oiq/oiq_match_pair.mli
+++ b/src/oiq/oiq_match_pair.mli
@@ -1,0 +1,4 @@
+type t
+
+val make : Oiq_tf.Resource.t -> Oiq_prices.Product.t -> t
+val to_yojson : t -> Yojson.Safe.t

--- a/src/oiq/oiq_prices.ml
+++ b/src/oiq/oiq_prices.ml
@@ -1,31 +1,52 @@
+module Price = struct
+  type t =
+    | Per_hour of float
+    | Per_operation of float
+    | Reserved of float
+  [@@deriving eq]
+
+  let to_yojson t = raise (Failure "POOP")
+
+  let of_yojson json =
+    let module P = struct
+      type t = {
+        usd : string; [@key "USD"]
+        unit : string;
+      }
+      [@@deriving of_yojson { strict = false }]
+    end in
+    CCResult.map
+      (function
+        | { P.usd; unit = "hr" } -> Per_hour (CCFloat.of_string_exn usd)
+        | { P.usd; unit = "op" } -> Per_operation (CCFloat.of_string_exn usd)
+        | _ -> raise (Failure "MEOW"))
+      (P.of_yojson json)
+end
+
 module Product = struct
   type t = {
     service : string;
     product_family : string;
     match_set_str : string;
-    price_info : string;
+    price_info : Price.t list;
   }
   [@@deriving yojson, eq]
 
   let of_row row =
     match row with
     | [ service; product_family; match_set_str; price_info ] ->
+        let price_info =
+          let json = Yojson.Safe.from_string price_info in
+          let module P = struct
+            type t = Price.t list [@@deriving of_yojson { strict = false }]
+          end in
+          Printf.printf "%s" price_info;
+          match P.of_yojson json with
+          | Ok items -> items
+          | Error e -> raise (Failure e)
+        in
         { service; product_family; match_set_str; price_info }
-    | _ -> raise (Failure "NYI")
+    | _ -> raise (Failure "MEEEEEEOOOOOOOW")
 
   let to_match_set t = CCResult.get_exn @@ Oiq_match_set.of_string t.match_set_str
-
-  (* price_info is a json string in the CSV. we parse it before printing our json *)
-  let to_yojson t =
-    let price_info_json =
-      try Yojson.Safe.from_string t.price_info
-      with Yojson.Safe.Util.Type_error (_, _) | Yojson.Json_error _ -> `String t.price_info
-    in
-    `Assoc
-      [
-        ("service", `String t.service);
-        ("product_family", `String t.product_family);
-        ("match_set_str", `String t.match_set_str);
-        ("price_info", price_info_json);
-      ]
 end

--- a/src/oiq/oiq_prices.ml
+++ b/src/oiq/oiq_prices.ml
@@ -1,0 +1,18 @@
+module Product = struct
+  type t = {
+    service : string;
+    product_family : string;
+    match_set_str : string;
+    price_info : string;
+  }
+
+  let of_row row =
+    match row with
+    | [ service; product_family; match_set_str; price_info ] ->
+        { service; product_family; match_set_str; price_info }
+    | _ -> raise (Failure "NYI")
+
+  let to_match_str t = t.match_set_str
+  let to_match_set t = raise (Failure "NYI")
+  let to_price_json t = raise (Failure "NYI")
+end

--- a/src/oiq/oiq_prices.ml
+++ b/src/oiq/oiq_prices.ml
@@ -14,5 +14,18 @@ module Product = struct
     | _ -> raise (Failure "NYI")
 
   let to_match_set t = CCResult.get_exn @@ Oiq_match_set.of_string t.match_set_str
-  let to_yojson t = to_yojson t
+
+  (* price_info is a json string in the CSV. we parse it before printing our json *)
+  let to_yojson t =
+    let price_info_json =
+      try Yojson.Safe.from_string t.price_info
+      with Yojson.Safe.Util.Type_error (_, _) | Yojson.Json_error _ -> `String t.price_info
+    in
+    `Assoc
+      [
+        ("service", `String t.service);
+        ("product_family", `String t.product_family);
+        ("match_set_str", `String t.match_set_str);
+        ("price_info", price_info_json);
+      ]
 end

--- a/src/oiq/oiq_prices.ml
+++ b/src/oiq/oiq_prices.ml
@@ -5,6 +5,7 @@ module Product = struct
     match_set_str : string;
     price_info : string;
   }
+  [@@deriving yojson, eq]
 
   let of_row row =
     match row with
@@ -12,7 +13,6 @@ module Product = struct
         { service; product_family; match_set_str; price_info }
     | _ -> raise (Failure "NYI")
 
-  let to_match_str t = t.match_set_str
-  let to_match_set t = raise (Failure "NYI")
-  let to_price_json t = raise (Failure "NYI")
+  let to_match_set t = CCResult.get_exn @@ Oiq_match_set.of_string t.match_set_str
+  let to_yojson t = to_yojson t
 end

--- a/src/oiq/oiq_prices.mli
+++ b/src/oiq/oiq_prices.mli
@@ -1,0 +1,8 @@
+module Product : sig
+  type t
+
+  val of_row : string list -> t
+  val to_match_str : t -> string
+  val to_match_set : t -> Oiq_match_set.t
+  val to_price_json : t -> Yojson.Safe.t
+end

--- a/src/oiq/oiq_prices.mli
+++ b/src/oiq/oiq_prices.mli
@@ -1,3 +1,7 @@
+module Price : sig
+  type t
+end
+
 module Product : sig
   type t
 

--- a/src/oiq/oiq_prices.mli
+++ b/src/oiq/oiq_prices.mli
@@ -2,7 +2,6 @@ module Product : sig
   type t
 
   val of_row : string list -> t
-  val to_match_str : t -> string
   val to_match_set : t -> Oiq_match_set.t
-  val to_price_json : t -> Yojson.Safe.t
+  val to_yojson : t -> Yojson.Safe.t
 end

--- a/src/oiq/oiq_tf.ml
+++ b/src/oiq/oiq_tf.ml
@@ -23,6 +23,7 @@ module Resource = struct
   type t = { data : Yojson.Safe.t }
 
   let of_yojson data = { data }
+  let to_yojson t = t.data
 
   let rec flatten ?(prefix = "") (json : Yojson.Safe.t) : (string * string) list =
     match json with

--- a/src/oiq/oiq_tf.ml
+++ b/src/oiq/oiq_tf.ml
@@ -23,7 +23,46 @@ module Resource = struct
   type t = { data : Yojson.Safe.t }
 
   let of_yojson data = { data }
-  let to_match_set t = raise (Failure "NYI")
+
+  let rec flatten ?(prefix = "") (json : Yojson.Safe.t) : (string * string) list =
+    match json with
+    | `Assoc fields ->
+        List.fold_left
+          (fun acc (key, value) ->
+            let new_prefix = if prefix = "" then key else prefix ^ "." ^ key in
+            let flattened = flatten ~prefix:new_prefix value in
+            acc @ flattened)
+          []
+          fields
+    | `List items ->
+        List.mapi
+          (fun idx item ->
+            let new_prefix = prefix ^ "." ^ string_of_int idx in
+            flatten ~prefix:new_prefix item)
+          items
+        |> List.concat
+    | `String s -> [ (prefix, s) ]
+    | `Int i -> [ (prefix, string_of_int i) ]
+    | `Float f -> [ (prefix, string_of_float f) ]
+    | `Bool b -> [ (prefix, string_of_bool b) ]
+    | `Null -> [ (prefix, "null") ]
+    | `Intlit s -> [ (prefix, s) ]
+    | `Tuple items ->
+        List.mapi
+          (fun idx item ->
+            let new_prefix =
+              if prefix = "" then string_of_int idx else prefix ^ "." ^ string_of_int idx
+            in
+            flatten ~prefix:new_prefix item)
+          items
+        |> List.concat
+    | `Variant (name, Some content) ->
+        let new_prefix = if prefix = "" then name else prefix ^ "." ^ name in
+        flatten ~prefix:new_prefix content
+    | `Variant (name, None) -> [ (prefix ^ "." ^ name, "") ]
+
+  let to_match_set t =
+    CCResult.get_exn @@ Oiq_match_set.of_list @@ Oiq_match_set.to_keys @@ flatten t.data
 end
 
 let rec load_resources json =

--- a/src/oiq/oiq_tf.mli
+++ b/src/oiq/oiq_tf.mli
@@ -4,6 +4,7 @@ module Resource : sig
   type t
 
   val to_match_set : t -> Oiq_match_set.t
+  val to_yojson : t -> Yojson.Safe.t
 end
 
 module Plan : sig


### PR DESCRIPTION
This is a minimal implementation of the CLI's match command.

Assuming the pricing CSV and a TF plan is available, the command can be run like this:

```
oiq_cli.native match -p ../oiqdata ../data/simpleweb.plan.json
``` 

The output will be a json blob with the following format:

```json
{
    "oiq": [
        {
            "resource": "<original json found in plan for resource>",
            "product": "<product info from new noise>"
        }
    ] 
}
```